### PR TITLE
fix: support both old and new TrueNAS unlock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,14 @@ api_key: ~/.secrets/truenas-api-key  # file path or literal
 skip_cert_verify: true
 
 # secrets: auto  # auto (default) | files | inline
+# truenas_version: "25.04"  # optional: skip version detection API call
 
 datasets:
   tank/syncthing: ~/.secrets/syncthing-key  # reads from file
   tank/photos: my-literal-passphrase        # used as-is (no such file)
 ```
+
+The `truenas_version` field is optional. When specified (e.g., `"25.04"` or `"24.10"`), it skips the automatic version detection API call. This is useful if you know your TrueNAS version and want to reduce API calls. TrueNAS 25.04+ uses a different unlock API than older versions.
 
 The `secrets` mode controls how values are interpreted:
 - **auto** (default): if file exists, read from it; otherwise use as literal

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -121,7 +121,8 @@ def mock_config_with_version() -> Config:
 
 @pytest.mark.anyio
 async def test_unlock(
-    mock_config_with_version: Config, mock_httpx_client: MagicMock,
+    mock_config_with_version: Config,
+    mock_httpx_client: MagicMock,
 ) -> None:
     """Test unlock logic."""
     mock_response = MagicMock(spec=httpx.Response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,16 +105,32 @@ async def test_is_locked(mock_config: Config, mock_httpx_client: MagicMock) -> N
         assert await client.is_locked(ds) is None
 
 
+@pytest.fixture
+def mock_config_with_version() -> Config:
+    """Return a mock configuration with version specified."""
+    return Config(
+        host="truenas.local",
+        api_key="secret-key",
+        secrets=SecretsMode.INLINE,
+        truenas_version="25.04",  # New version, uses "options"
+        datasets=[
+            Dataset(path="tank/secure", secret="pass1"),
+        ],
+    )
+
+
 @pytest.mark.anyio
-async def test_unlock(mock_config: Config, mock_httpx_client: MagicMock) -> None:
+async def test_unlock(
+    mock_config_with_version: Config, mock_httpx_client: MagicMock,
+) -> None:
     """Test unlock logic."""
     mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 200
     mock_httpx_client.request.return_value = mock_response
 
-    async with TrueNasClient(mock_config) as client:
+    async with TrueNasClient(mock_config_with_version) as client:
         client._client = mock_httpx_client  # noqa: SLF001
-        ds = mock_config.datasets[0]
+        ds = mock_config_with_version.datasets[0]
 
         assert await client.unlock(ds) is True
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -88,7 +88,8 @@ class TestClientVersionDetection:
 
     @pytest.mark.anyio
     async def test_uses_config_version_when_provided(
-        self, mock_config_with_version: Config,
+        self,
+        mock_config_with_version: Config,
     ) -> None:
         """Test that config version is used when provided, skipping API call."""
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -102,16 +103,13 @@ class TestClientVersionDetection:
                 # Should use old API (24.10 < 25.04)
                 assert use_new is False
                 # Should NOT have made a version API call
-                version_calls = [
-                    call
-                    for call in mock_client.request.call_args_list
-                    if "system/version" in str(call)
-                ]
+                version_calls = [call for call in mock_client.request.call_args_list if "system/version" in str(call)]
                 assert len(version_calls) == 0
 
     @pytest.mark.anyio
     async def test_fetches_version_when_not_in_config(
-        self, mock_config_no_version: Config,
+        self,
+        mock_config_no_version: Config,
     ) -> None:
         """Test that version is fetched from API when not in config."""
         mock_response = MagicMock(spec=httpx.Response)
@@ -154,7 +152,8 @@ class TestClientVersionDetection:
 
     @pytest.mark.anyio
     async def test_unlock_uses_old_api_param(
-        self, mock_config_with_version: Config,
+        self,
+        mock_config_with_version: Config,
     ) -> None:
         """Test that unlock uses unlock_options for old TrueNAS versions."""
         mock_response = MagicMock(spec=httpx.Response)
@@ -171,11 +170,7 @@ class TestClientVersionDetection:
                 await client.unlock(ds)
 
                 # Check the unlock call used unlock_options
-                unlock_call = next(
-                    call
-                    for call in mock_client.request.call_args_list
-                    if "unlock" in str(call)
-                )
+                unlock_call = next(call for call in mock_client.request.call_args_list if "unlock" in str(call))
                 json_arg = unlock_call.kwargs.get("json", {})
                 assert "unlock_options" in json_arg
                 assert "options" not in json_arg

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,56 +10,56 @@ from truenas_unlock import (
     Dataset,
     SecretsMode,
     TrueNasClient,
-    parse_truenas_version,
-    uses_new_unlock_api,
+    _parse_truenas_version,
+    _uses_new_unlock_api,
 )
 
 
 class TestParseVersion:
-    """Tests for parse_truenas_version function."""
+    """Tests for _parse_truenas_version function."""
 
     def test_new_format(self) -> None:
         """Test parsing new format: TrueNAS-25.04.0."""
-        assert parse_truenas_version("TrueNAS-25.04.0") == (25, 4)
+        assert _parse_truenas_version("TrueNAS-25.04.0") == (25, 4)
 
     def test_old_format(self) -> None:
         """Test parsing old format: TrueNAS-SCALE-24.10.2.1."""
-        assert parse_truenas_version("TrueNAS-SCALE-24.10.2.1") == (24, 10)
+        assert _parse_truenas_version("TrueNAS-SCALE-24.10.2.1") == (24, 10)
 
     def test_simple_version(self) -> None:
         """Test parsing simple version string."""
-        assert parse_truenas_version("25.04") == (25, 4)
-        assert parse_truenas_version("24.10.2") == (24, 10)
+        assert _parse_truenas_version("25.04") == (25, 4)
+        assert _parse_truenas_version("24.10.2") == (24, 10)
 
     def test_invalid_version(self) -> None:
         """Test parsing invalid version string."""
-        assert parse_truenas_version("invalid") is None
-        assert parse_truenas_version("") is None
+        assert _parse_truenas_version("invalid") is None
+        assert _parse_truenas_version("") is None
 
     def test_edge_cases(self) -> None:
         """Test edge cases."""
-        assert parse_truenas_version("25.04.2.6") == (25, 4)
-        assert parse_truenas_version("1.0") == (1, 0)
+        assert _parse_truenas_version("25.04.2.6") == (25, 4)
+        assert _parse_truenas_version("1.0") == (1, 0)
 
 
 class TestUsesNewUnlockApi:
-    """Tests for uses_new_unlock_api function."""
+    """Tests for _uses_new_unlock_api function."""
 
     def test_new_api_versions(self) -> None:
         """Test versions that should use new API (>= 25.04)."""
-        assert uses_new_unlock_api((25, 4)) is True
-        assert uses_new_unlock_api((25, 10)) is True
-        assert uses_new_unlock_api((26, 0)) is True
+        assert _uses_new_unlock_api((25, 4)) is True
+        assert _uses_new_unlock_api((25, 10)) is True
+        assert _uses_new_unlock_api((26, 0)) is True
 
     def test_old_api_versions(self) -> None:
         """Test versions that should use old API (< 25.04)."""
-        assert uses_new_unlock_api((24, 10)) is False
-        assert uses_new_unlock_api((24, 4)) is False
-        assert uses_new_unlock_api((25, 3)) is False
+        assert _uses_new_unlock_api((24, 10)) is False
+        assert _uses_new_unlock_api((24, 4)) is False
+        assert _uses_new_unlock_api((25, 3)) is False
 
     def test_none_defaults_to_new(self) -> None:
         """Test that None version defaults to new API."""
-        assert uses_new_unlock_api(None) is True
+        assert _uses_new_unlock_api(None) is True
 
 
 class TestClientVersionDetection:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,181 @@
+"""Tests for TrueNAS version detection and API compatibility."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from truenas_unlock import (
+    Config,
+    Dataset,
+    SecretsMode,
+    TrueNasClient,
+    parse_truenas_version,
+    uses_new_unlock_api,
+)
+
+
+class TestParseVersion:
+    """Tests for parse_truenas_version function."""
+
+    def test_new_format(self) -> None:
+        """Test parsing new format: TrueNAS-25.04.0."""
+        assert parse_truenas_version("TrueNAS-25.04.0") == (25, 4)
+
+    def test_old_format(self) -> None:
+        """Test parsing old format: TrueNAS-SCALE-24.10.2.1."""
+        assert parse_truenas_version("TrueNAS-SCALE-24.10.2.1") == (24, 10)
+
+    def test_simple_version(self) -> None:
+        """Test parsing simple version string."""
+        assert parse_truenas_version("25.04") == (25, 4)
+        assert parse_truenas_version("24.10.2") == (24, 10)
+
+    def test_invalid_version(self) -> None:
+        """Test parsing invalid version string."""
+        assert parse_truenas_version("invalid") is None
+        assert parse_truenas_version("") is None
+
+    def test_edge_cases(self) -> None:
+        """Test edge cases."""
+        assert parse_truenas_version("25.04.2.6") == (25, 4)
+        assert parse_truenas_version("1.0") == (1, 0)
+
+
+class TestUsesNewUnlockApi:
+    """Tests for uses_new_unlock_api function."""
+
+    def test_new_api_versions(self) -> None:
+        """Test versions that should use new API (>= 25.04)."""
+        assert uses_new_unlock_api((25, 4)) is True
+        assert uses_new_unlock_api((25, 10)) is True
+        assert uses_new_unlock_api((26, 0)) is True
+
+    def test_old_api_versions(self) -> None:
+        """Test versions that should use old API (< 25.04)."""
+        assert uses_new_unlock_api((24, 10)) is False
+        assert uses_new_unlock_api((24, 4)) is False
+        assert uses_new_unlock_api((25, 3)) is False
+
+    def test_none_defaults_to_new(self) -> None:
+        """Test that None version defaults to new API."""
+        assert uses_new_unlock_api(None) is True
+
+
+class TestClientVersionDetection:
+    """Tests for TrueNasClient version detection."""
+
+    @pytest.fixture
+    def mock_config_no_version(self) -> Config:
+        """Return a mock config without truenas_version."""
+        return Config(
+            host="truenas.local",
+            api_key="secret-key",
+            secrets=SecretsMode.INLINE,
+            datasets=[Dataset(path="tank/secure", secret="pass1")],
+        )
+
+    @pytest.fixture
+    def mock_config_with_version(self) -> Config:
+        """Return a mock config with truenas_version."""
+        return Config(
+            host="truenas.local",
+            api_key="secret-key",
+            secrets=SecretsMode.INLINE,
+            truenas_version="24.10",  # Old version
+            datasets=[Dataset(path="tank/secure", secret="pass1")],
+        )
+
+    @pytest.mark.anyio
+    async def test_uses_config_version_when_provided(
+        self, mock_config_with_version: Config,
+    ) -> None:
+        """Test that config version is used when provided, skipping API call."""
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value = mock_client
+            mock_client.__aenter__.return_value = mock_client
+
+            async with TrueNasClient(mock_config_with_version) as client:
+                use_new = await client._get_use_new_api()  # noqa: SLF001
+
+                # Should use old API (24.10 < 25.04)
+                assert use_new is False
+                # Should NOT have made a version API call
+                version_calls = [
+                    call
+                    for call in mock_client.request.call_args_list
+                    if "system/version" in str(call)
+                ]
+                assert len(version_calls) == 0
+
+    @pytest.mark.anyio
+    async def test_fetches_version_when_not_in_config(
+        self, mock_config_no_version: Config,
+    ) -> None:
+        """Test that version is fetched from API when not in config."""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = "TrueNAS-25.04.0"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.request.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+            mock_client.__aenter__.return_value = mock_client
+
+            async with TrueNasClient(mock_config_no_version) as client:
+                use_new = await client._get_use_new_api()  # noqa: SLF001
+
+                # Should use new API (25.04 >= 25.04)
+                assert use_new is True
+
+    @pytest.mark.anyio
+    async def test_caches_api_detection(self, mock_config_no_version: Config) -> None:
+        """Test that API style is cached after first detection."""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = "TrueNAS-25.04.0"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.request.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+            mock_client.__aenter__.return_value = mock_client
+
+            async with TrueNasClient(mock_config_no_version) as client:
+                # First call
+                await client._get_use_new_api()  # noqa: SLF001
+                first_call_count = mock_client.request.call_count
+
+                # Second call should use cached value
+                await client._get_use_new_api()  # noqa: SLF001
+                assert mock_client.request.call_count == first_call_count
+
+    @pytest.mark.anyio
+    async def test_unlock_uses_old_api_param(
+        self, mock_config_with_version: Config,
+    ) -> None:
+        """Test that unlock uses unlock_options for old TrueNAS versions."""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.request.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+            mock_client.__aenter__.return_value = mock_client
+
+            async with TrueNasClient(mock_config_with_version) as client:
+                ds = mock_config_with_version.datasets[0]
+                await client.unlock(ds)
+
+                # Check the unlock call used unlock_options
+                unlock_call = next(
+                    call
+                    for call in mock_client.request.call_args_list
+                    if "unlock" in str(call)
+                )
+                json_arg = unlock_call.kwargs.get("json", {})
+                assert "unlock_options" in json_arg
+                assert "options" not in json_arg

--- a/truenas_unlock.py
+++ b/truenas_unlock.py
@@ -101,7 +101,7 @@ LAUNCHD_PLIST = """\
 TRUENAS_NEW_API_VERSION = (25, 4)
 
 
-def parse_truenas_version(version_string: str) -> tuple[int, int] | None:
+def _parse_truenas_version(version_string: str) -> tuple[int, int] | None:
     """Parse TrueNAS version string to (major, minor) tuple.
 
     Handles formats like:
@@ -116,7 +116,7 @@ def parse_truenas_version(version_string: str) -> tuple[int, int] | None:
     return None
 
 
-def uses_new_unlock_api(version: tuple[int, int] | None) -> bool:
+def _uses_new_unlock_api(version: tuple[int, int] | None) -> bool:
     """Determine if the TrueNAS version uses the new 'options' parameter.
 
     Returns True for versions >= 25.04, False otherwise.
@@ -250,12 +250,12 @@ class TrueNasClient:
 
         # Use config version if provided (skips API call)
         if self.config.truenas_version:
-            version = parse_truenas_version(self.config.truenas_version)
+            version = _parse_truenas_version(self.config.truenas_version)
         else:
             version_str = await self.get_version()
-            version = parse_truenas_version(version_str) if version_str else None
+            version = _parse_truenas_version(version_str) if version_str else None
 
-        self._use_new_api = uses_new_unlock_api(version)
+        self._use_new_api = _uses_new_unlock_api(version)
         return self._use_new_api
 
     async def _request(

--- a/truenas_unlock.py
+++ b/truenas_unlock.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import os
 import platform
+import re
 import shutil
 import subprocess
 import time
@@ -41,6 +42,7 @@ host: 192.168.1.214:443
 api_key: ~/.secrets/truenas-api-key  # file path or literal value
 skip_cert_verify: true
 # secrets: auto  # auto (default), files, or inline
+# truenas_version: "25.04"  # optional: skip version detection API call
 
 datasets:
   tank/syncthing: ~/.secrets/syncthing-key
@@ -94,6 +96,37 @@ LAUNCHD_PLIST = """\
 """
 
 
+# TrueNAS 25.04+ uses "options", older versions use "unlock_options"
+# See: https://github.com/basnijholt/truenas-unlock/issues/5
+TRUENAS_NEW_API_VERSION = (25, 4)
+
+
+def parse_truenas_version(version_string: str) -> tuple[int, int] | None:
+    """Parse TrueNAS version string to (major, minor) tuple.
+
+    Handles formats like:
+    - "TrueNAS-25.04.0"
+    - "TrueNAS-SCALE-24.10.2.1"
+    - "25.04.0"
+    """
+    # Extract version numbers from the string
+    match = re.search(r"(\d+)\.(\d+)", version_string)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    return None
+
+
+def uses_new_unlock_api(version: tuple[int, int] | None) -> bool:
+    """Determine if the TrueNAS version uses the new 'options' parameter.
+
+    Returns True for versions >= 25.04, False otherwise.
+    Defaults to True (new API) if version cannot be determined.
+    """
+    if version is None:
+        return True  # Default to new API
+    return version >= TRUENAS_NEW_API_VERSION
+
+
 class SecretsMode(str, Enum):
     """How to interpret secret values."""
 
@@ -143,6 +176,7 @@ class Config(BaseModel):
     api_key: str  # file path or literal value
     skip_cert_verify: bool = False
     secrets: SecretsMode = SecretsMode.AUTO
+    truenas_version: str | None = None  # e.g., "25.04" or "24.10" - skips version detection
     datasets: list[Dataset]
 
     def get_api_key(self) -> str:  # noqa: D102
@@ -169,6 +203,7 @@ class TrueNasClient:
     def __init__(self, config: Config) -> None:  # noqa: D107
         self.config = config
         self._client: httpx.AsyncClient | None = None
+        self._use_new_api: bool | None = None  # Cached after first detection
 
     async def __aenter__(self) -> TrueNasClient:  # noqa: D105, PYI034
         self._client = httpx.AsyncClient(
@@ -195,6 +230,33 @@ class TrueNasClient:
     @property
     def _base_url(self) -> str:
         return f"https://{self.config.host}/api/v2.0"
+
+    async def get_version(self) -> str | None:
+        """Get TrueNAS version string."""
+        response = await self._request("GET", "system/version", quiet=True)
+        if response:
+            try:
+                # Response is a plain string like "TrueNAS-25.04.0"
+                result = response.json()
+                return str(result) if result else None
+            except ValueError:
+                return response.text.strip().strip('"')
+        return None
+
+    async def _get_use_new_api(self) -> bool:
+        """Determine if we should use new API style, with caching."""
+        if self._use_new_api is not None:
+            return self._use_new_api
+
+        # Use config version if provided (skips API call)
+        if self.config.truenas_version:
+            version = parse_truenas_version(self.config.truenas_version)
+        else:
+            version_str = await self.get_version()
+            version = parse_truenas_version(version_str) if version_str else None
+
+        self._use_new_api = uses_new_unlock_api(version)
+        return self._use_new_api
 
     async def _request(
         self,
@@ -243,16 +305,18 @@ class TrueNasClient:
     async def unlock(self, dataset: Dataset) -> bool:
         """Unlock a dataset."""
         passphrase = dataset.get_passphrase(self.config.secrets)
-        payload = {
-            "id": dataset.path,
-            "options": {
-                "key_file": False,
-                "recursive": False,
-                "force": True,
-                "toggle_attachments": True,
-                "datasets": [{"name": dataset.path, "passphrase": passphrase}],
-            },
+        options = {
+            "key_file": False,
+            "recursive": False,
+            "force": True,
+            "toggle_attachments": True,
+            "datasets": [{"name": dataset.path, "passphrase": passphrase}],
         }
+
+        # TrueNAS 25.04+ uses "options", older versions use "unlock_options"
+        use_new_api = await self._get_use_new_api()
+        options_key = "options" if use_new_api else "unlock_options"
+        payload = {"id": dataset.path, options_key: options}
 
         if not await self._request("POST", "pool/dataset/unlock", json=payload):
             return False


### PR DESCRIPTION
## Summary

- Add automatic TrueNAS version detection to use the correct unlock API parameter
- TrueNAS 25.04+ uses `options`, older versions use `unlock_options`
- Add optional `truenas_version` config field to skip version detection API call
- Add comprehensive tests for version parsing and API compatibility

## Details

The TrueNAS API changed between versions:
- **Older versions (< 25.04)**: use `unlock_options` parameter
- **Newer versions (≥ 25.04)**: use `options` parameter

This PR adds automatic version detection via the `/api/v2.0/system/version` endpoint and uses the correct parameter based on the detected version. The version detection result is cached to avoid repeated API calls.

Users can also specify `truenas_version: "25.04"` (or `"24.10"` etc.) in their config to skip the version detection API call entirely.

Fixes #5

## Test plan

- [x] All 63 tests pass (including 12 new tests for version parsing)
- [x] Linting and type checking pass
- [x] Test with TrueNAS 25.04+ (uses `options`)
- [x] Test with TrueNAS < 25.04 (uses `unlock_options`)